### PR TITLE
move testing dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/phimimms/taskQueue/issues"
   },
   "homepage": "https://github.com/phimimms/taskQueue#readme",
-  "dependencies": {
+  "devDependencies": {
     "expect": "^1.20.2",
     "mocha": "^3.2.0"
   }


### PR DESCRIPTION
This is to prevent these requirements from getting pulled into users of the library.